### PR TITLE
Fix deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: ./scripts/travis-deploy.sh
+    script: bash ./scripts/travis-deploy.sh
     on:
       all_branches: true

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -4,10 +4,10 @@
 if [ ! -z "$TRAVIS_TAG" ]
 then 
     echo "Tag found"
+    cd Transbank
     if ( echo $TRAVIS_TAG | egrep -i '^v[0-9]+\.[0-9]+\.[0-9]+')
     then
             VERSION_NUMBER=${TRAVIS_TAG:1}
-            cd Transbank
             dotnet pack Transbank.csproj -c release --version-prefix $VERSION_NUMBER --output nupkgs -v d
     else
             dotnet pack Transbank.csproj -c release --version-suffix ci-$TRAVIS_BUILD_ID


### PR DESCRIPTION
Deploy script has to be executed with bash, because Ubuntu default shell points to dash, which does not support string substitution.