### PR TITLE
Skip build of branch if there is an open PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2017
+skip_branch_with_pr: true
 cache:
   - '%LocalAppData%\NuGet\Cache'
   - '%LocalAppData%\NuGet\v3-cache'


### PR DESCRIPTION
This is done to avoid the double build when a pr is open
pr will still be built with the synchronize event.