### PR TITLE
Deploy pre-releases only if new build button is pressed

### DIFF
--- a/scripts/appveyor-before-deploy.ps1
+++ b/scripts/appveyor-before-deploy.ps1
@@ -6,8 +6,8 @@ if ($env:APPVEYOR_REPO_TAG_NAME -Match "^v[0-9]+\.[0-9]+\.[0-9]+" ){
     dotnet.exe pack Transbank.csproj -c release  -p:Version=$VERSION_NUMBER --output nupkgs
     Write-Host "Done"
 }
-else{
-    Write-Host "No Version Tag Found deploy prerelease to Nuget"
+elseif ($env:APPVEYOR_FORCED_BUILD -Match "true") {
+    Write-Host "New build button presed and no version Tag Found deploy prerelease to Nuget"
     dotnet.exe pack Transbank.csproj -c release --version-suffix ci-$env:APPVEYOR_BUILD_ID --output nupkgs
     Write-Host "Done"
 }


### PR DESCRIPTION
This is to avoid generating a prerelease with every branch merged to master.