### PR TITLE
Fix java 1.6.0.211 compativility

### DIFF
--- a/Transbank/Webpay/Common/Constants.cs
+++ b/Transbank/Webpay/Common/Constants.cs
@@ -21,7 +21,7 @@ namespace Transbank.Webpay.Common
         public static String SECURITY = "Security";
         public static String WSSE = "wsse";
         public static String NS_WEBSERVICE_UTILITY = "xmlns:wsu";
-        public static String ID = "id";
+        public static String ID = "Id";
         public static String SOAPENV = "soapenv";
         public static String NS_SOAP = "xmlns:soap";
         public static String NS_SER = "xmlns:ser";

--- a/Transbank/Webpay/Security/WSSecuritySignature.cs
+++ b/Transbank/Webpay/Security/WSSecuritySignature.cs
@@ -80,7 +80,7 @@ namespace Transbank.Webpay.Security
 
             InitializeSoapEnv(soap);
 
-            SignedXml signedXml = new SignedXml(soap);
+            XmlSignature signedXml = new XmlSignature(soap);
 
             KeyInfo keyInfo = new KeyInfo();
             signedXml.SigningKey = certificateSignature.PrivateKey;

--- a/Transbank/Webpay/Security/XmlSignature.cs
+++ b/Transbank/Webpay/Security/XmlSignature.cs
@@ -12,6 +12,10 @@ namespace Transbank.Webpay.Security
         {
         }
 
+        public XmlSignature(XmlDocument xml) : base(xml)
+        {
+        }
+
         public override XmlElement GetIdElement(XmlDocument document, string idValue)
         {
             XmlElement idElem = base.GetIdElement(document, idValue);
@@ -19,9 +23,9 @@ namespace Transbank.Webpay.Security
             if (idElem == null)
             {
                 XmlNamespaceManager nsmanager = new XmlNamespaceManager(document.NameTable);
-                nsmanager.AddNamespace(Constants.WSU, Constants.WSSECURITY_UTILITY);
+                nsmanager.AddNamespace("wsu", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd");
 
-                idElem = (XmlElement)document.SelectSingleNode(String.Format(Constants.WSU_ID, idValue), nsmanager);
+                idElem = (XmlElement)document.SelectSingleNode("//*[@wsu:Id=\"" + idValue + "\"]", nsmanager) as XmlElement;
 
                 if (idElem == null)
                 {


### PR DESCRIPTION
- Change tag `id` to `Id` in the xml body.
  - The server with this Java version return the error `com.sun.org.apache.xml.internal.security.utils.resolver.ResourceResolverException: Can not resolve element with ID Body` with the current implementation. The error is based on the body ID tag, more specifically the XML validation requires that the ID tag must be sent with the initial capitalized

- Change SignedXml to allow the `Id` tag
  - Is unable to sign element by Id attribute when there's a namespace prefix, The xmlCheck return the `Malformed Reference Element'` error the solution is override the `GetIdElement` method.