### PR TITLE
Fix condition to set the Transbank cert automatically

### DIFF
--- a/Transbank/Webpay/Webpay.cs
+++ b/Transbank/Webpay/Webpay.cs
@@ -17,7 +17,7 @@ namespace Transbank.Webpay
 
         public Webpay(Configuration param)
         {
-            if (param.WebpayCertPath != null)
+            if (string.IsNullOrEmpty(param.WebpayCertPath))
                 switch (param.Environment)
                 {
                     case "PRODUCCION":


### PR DESCRIPTION
By an error in the condition the Transbank public cert was not being assigned automatically 