### PR TITLE
Fix headers, let request service handle them

### DIFF
--- a/Transbank/Common/Options.cs
+++ b/Transbank/Common/Options.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace Transbank.Common
 {
@@ -9,19 +8,6 @@ namespace Transbank.Common
         private string _apiKey;
         private IIntegrationType _integrationType;
         
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-        
-        public RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "headers can't be null."
-                              );
-        }
-
         public string CommerceCode
         {
             get => _commerceCode;
@@ -46,12 +32,11 @@ namespace Transbank.Common
                 );
         }
 
-        public Options(string commerceCode, string apiKey, IIntegrationType integrationType, RequestServiceHeaders headers)
+        public Options(string commerceCode, string apiKey, IIntegrationType integrationType)
         {
             CommerceCode = commerceCode;
             ApiKey = apiKey;
             IntegrationType = integrationType;
-            Headers = headers;
         }
 
         public override string ToString()

--- a/Transbank/Common/RequestService.cs
+++ b/Transbank/Common/RequestService.cs
@@ -1,26 +1,28 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Transbank.Exceptions;
+using Transbank.Common;
 
 namespace Transbank.Common
 {
     public static class RequestService
     {
         private static readonly string CONTENT_TYPE = "application/json";
-        
+
         private static void AddRequiredHeaders(HttpClient client, string commerceCode, string apiKey, RequestServiceHeaders headers)
         {
             var header = new MediaTypeWithQualityHeaderValue(CONTENT_TYPE);
             client.DefaultRequestHeaders.Accept.Add(header);
-            client.DefaultRequestHeaders.Add(headers.CommerceCodeHeaderName, commerceCode);
-            client.DefaultRequestHeaders.Add(headers.ApiKeyHeaderName, apiKey);
+            client.DefaultRequestHeaders.Add(headers.CommerceCodeHeader, commerceCode);
+            client.DefaultRequestHeaders.Add(headers.ApiKeyHeader, apiKey);
         }
 
-        public static string Perform<T>(BaseRequest request, Options options) where T : TransbankException
+        public static string Perform<T>(BaseRequest request, Options options, RequestServiceHeaders requestServiceHeaders) where T : TransbankException
         {
             var message = new HttpRequestMessage(request.Method, new Uri(options.IntegrationType.ApiBase + request.Endpoint));
             if (request.Method != HttpMethod.Get)
@@ -29,9 +31,9 @@ namespace Transbank.Common
 
             using (var client = new HttpClient())
             {
-                AddRequiredHeaders(client, options.CommerceCode, options.ApiKey, options.Headers);
-                var response = client.SendAsync(message)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                AddRequiredHeaders(client, options.CommerceCode, options.ApiKey, requestServiceHeaders);
+                var response = client.SendAsync(message).ConfigureAwait(false)
+                    .GetAwaiter().GetResult();
                 var jsonResponse = response.Content.ReadAsStringAsync()
                     .ConfigureAwait(false).GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
@@ -43,6 +45,12 @@ namespace Transbank.Common
                 }
                 return jsonResponse;
             }
+        }
+
+        public static string Perform<T>(BaseRequest request, Options options) where T : TransbankException
+        {
+            // Call perform with default headers
+            return Perform<T>(request, options, new RequestServiceHeaders());
         }
     }
 }

--- a/Transbank/Common/RequestService.cs
+++ b/Transbank/Common/RequestService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -10,7 +10,7 @@ using Transbank.Common;
 
 namespace Transbank.Common
 {
-    public static class RequestService
+    internal static class RequestService
     {
         private static readonly string CONTENT_TYPE = "application/json";
 

--- a/Transbank/Common/RequestServiceHeaders.cs
+++ b/Transbank/Common/RequestServiceHeaders.cs
@@ -5,18 +5,21 @@ namespace Transbank.Common
 {
     public class RequestServiceHeaders
     {
-        [DefaultValue("Tbk-Api-Key-Id")]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string ApiKeyHeaderName { get; set; }
-        
-        [DefaultValue("Tbk-Api-Key-Secret")]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string CommerceCodeHeaderName { get; set; }
 
-        public RequestServiceHeaders(string apiKeyHeaderName, string commerceCodeHeaderName)
+        public string CommerceCodeHeader { get; set; }
+
+        public string ApiKeyHeader { get; set; }
+
+        public RequestServiceHeaders()
         {
-            ApiKeyHeaderName = apiKeyHeaderName;
-            CommerceCodeHeaderName = commerceCodeHeaderName;
+            CommerceCodeHeader = "Tbk-Api-Key-Id";
+            ApiKeyHeader = "Tbk-Api-Key-Secret";
+        }
+
+        public RequestServiceHeaders(string apiKeyHeader, string commerceCodeHeader)
+        {
+            CommerceCodeHeader = commerceCodeHeader;
+            ApiKeyHeader = apiKeyHeader;
         }
     }
 }

--- a/Transbank/Common/RequestServiceHeaders.cs
+++ b/Transbank/Common/RequestServiceHeaders.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Transbank.Common
 {
-    public class RequestServiceHeaders
+    internal class RequestServiceHeaders
     {
 
         public string CommerceCodeHeader { get; set; }

--- a/Transbank/PatpassRest/PatpassByWebpay/Transaction.cs
+++ b/Transbank/PatpassRest/PatpassByWebpay/Transaction.cs
@@ -5,7 +5,6 @@ using Transbank.Exceptions;
 using Transbank.Patpass.Common;
 using Transbank.Patpass.PatpassByWebpay.Requests;
 using Transbank.Patpass.PatpassByWebpay.Responses;
-using RequestService = Transbank.Common.RequestService;
 
 namespace Transbank.Patpass.PatpassByWebpay
 {
@@ -14,19 +13,7 @@ namespace Transbank.Patpass.PatpassByWebpay
         private static string _commerceCode = "597055555550";
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
         private static PatpassByWebpayIntegrationType _integrationType = PatpassByWebpayIntegrationType.Test;
-        
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
 
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
         public static string CommerceCode
         {
             get => _commerceCode;
@@ -51,11 +38,9 @@ namespace Transbank.Patpass.PatpassByWebpay
             );
         }
 
-        
-
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static CreateResponse Create(string buyOrder, string sessionId, decimal amount, string returnUrl, string serviceId, string cardHolderId,

--- a/Transbank/PatpassRest/PatpassComercio/Inscription.cs
+++ b/Transbank/PatpassRest/PatpassComercio/Inscription.cs
@@ -46,13 +46,6 @@ namespace Transbank.Patpass.PatpassComercio
                                           nameof(value), "Integration type can't be null");
         }
 
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                 nameof(value), " Headers can't be null");
-        }
-
         public static Options DefaultOptions()
         {
             return new Options(CommerceCode, ApiKey, IntegrationType);

--- a/Transbank/PatpassRest/PatpassComercio/Inscription.cs
+++ b/Transbank/PatpassRest/PatpassComercio/Inscription.cs
@@ -16,6 +16,9 @@ namespace Transbank.Patpass.PatpassComercio
         private static string _commerceCode = "28299257";
         private static string _apiKey = "cxxXQgGD9vrVe4M41FIt";
         private static PatpassComercioIntegrationType _integrationType = PatpassComercioIntegrationType.Test;
+
+        // The authentication headers for this product are different, these have
+        // to be used. You can put them in the Perform method of the RequestService
         private static string _apiKeyHeaderName = "Authorization";
         private static string _commerceCodeHeaderName = "commerceCode";
 
@@ -52,7 +55,7 @@ namespace Transbank.Patpass.PatpassComercio
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static StartResponse Start(
@@ -74,23 +77,10 @@ namespace Transbank.Patpass.PatpassComercio
         )
         {
             return Start(
-                url,
-                name,
-                fLastname,
-                sLastname,
-                rut,
-                serviceId,
-                finalUrl,
-                maxAmount,
-                phoneNumber,
-                mobileNumber,
-                patpassName,
-                personEmail,
-                commerceEmail,
-                address,
-                city, 
-                DefaultOptions()
-                );
+                url, name, fLastname, sLastname, rut, serviceId, finalUrl,
+                maxAmount, phoneNumber, mobileNumber, patpassName, personEmail,
+                commerceEmail, address, city, DefaultOptions()
+            );
         }
 
         public static StartResponse Start(
@@ -118,24 +108,11 @@ namespace Transbank.Patpass.PatpassComercio
             return ExceptionHandler.Perform<StartResponse, InscriptionStartException>(() =>
             {
                 var request = new StartRequest(
-                    url,
-                    name,
-                    fLastname,
-                    sLastname,
-                    rut,
-                    serviceId,
-                    finalUrl,
-                    options.CommerceCode,
-                    mAmount,
-                    phoneNumber,
-                    mobileNumber,
-                    patpassName,
-                    personEmail,
-                    commerceEmail,
-                    address,
-                    city
+                    url, name, fLastname, sLastname, rut, serviceId, finalUrl,
+                    options.CommerceCode, mAmount, phoneNumber, mobileNumber,
+                    patpassName, personEmail, commerceEmail, address, city
                 );
-                var response = RequestService.Perform<InscriptionStartException>(request, options);
+                var response = RequestService.Perform<InscriptionStartException>(request, options, _headers);
 
                 return JsonConvert.DeserializeObject<StartResponse>(response);
             });
@@ -153,7 +130,7 @@ namespace Transbank.Patpass.PatpassComercio
             {
                 var statusRequest = new StatusRequest(token);
                 var response = RequestService.Perform<InscriptionStatusException>(
-                    statusRequest, options);
+                    statusRequest, options, _headers);
 
                 return JsonConvert.DeserializeObject<StatusResponse>(response);
             });

--- a/Transbank/PatpassRest/PatpassComercio/Requests/StatusRequest.cs
+++ b/Transbank/PatpassRest/PatpassComercio/Requests/StatusRequest.cs
@@ -12,7 +12,7 @@ namespace Transbank.Patpass.PatpassComercio.Requests
 
         internal StatusRequest(
             string token
-            ) : base($"restpatpass/v1/services/status",
+            ) : base($"/restpatpass/v1/services/status",
                 HttpMethod.Post)
         {
             Token = token;

--- a/Transbank/PatpassRest/PatpassComercio/Requests/StatusRequest.cs
+++ b/Transbank/PatpassRest/PatpassComercio/Requests/StatusRequest.cs
@@ -12,7 +12,7 @@ namespace Transbank.Patpass.PatpassComercio.Requests
 
         internal StatusRequest(
             string token
-            ) : base($"/restpatpass/v1/services/status",
+            ) : base($"restpatpass/v1/services/status",
                 HttpMethod.Post)
         {
             Token = token;

--- a/Transbank/WebpayRest/Oneclick/MallTransaction.cs
+++ b/Transbank/WebpayRest/Oneclick/MallTransaction.cs
@@ -19,19 +19,6 @@ namespace Transbank.Webpay.Oneclick
         private static string[] _storeCodes = { "597055555542", "597055555543" };
 
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
-        
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
 
         public static string CommerceCode
         {
@@ -59,7 +46,7 @@ namespace Transbank.Webpay.Oneclick
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
         
         public static MallAuthorizeResponse Authorize(string userName, string tbkUser,

--- a/Transbank/WebpayRest/Oneclick/Oneclick.cs
+++ b/Transbank/WebpayRest/Oneclick/Oneclick.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Remoting.Messaging;
 using Transbank.Common;
 using Transbank.Webpay.Common;
 namespace Transbank.Webpay.Oneclick
@@ -10,19 +9,6 @@ namespace Transbank.Webpay.Oneclick
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
         private static string[] _storeCodes = { "597055555542", "597055555543" };
         
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
-
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
 
         public static string CommerceCode
@@ -51,7 +37,7 @@ namespace Transbank.Webpay.Oneclick
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
     }
 }

--- a/Transbank/WebpayRest/TransaccionCompleta/FullTransaction.cs
+++ b/Transbank/WebpayRest/TransaccionCompleta/FullTransaction.cs
@@ -14,19 +14,6 @@ namespace Transbank.Webpay.TransaccionCompleta
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
 
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
-        
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
 
         public static string CommerceCode
         {
@@ -54,7 +41,7 @@ namespace Transbank.Webpay.TransaccionCompleta
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
         public static CreateResponse Create(
             string buyOrder,

--- a/Transbank/WebpayRest/TransaccionCompletaMall/MallFullTransaction.cs
+++ b/Transbank/WebpayRest/TransaccionCompletaMall/MallFullTransaction.cs
@@ -17,19 +17,6 @@ namespace Transbank.Webpay.TransaccionCompletaMall
         
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
         
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
-        
         public static string CommerceCode
         {
             get => _commerceCode;
@@ -56,7 +43,7 @@ namespace Transbank.Webpay.TransaccionCompletaMall
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static MallCreateResponse Create(

--- a/Transbank/WebpayRest/WebpayPlus/DeferredTransaction.cs
+++ b/Transbank/WebpayRest/WebpayPlus/DeferredTransaction.cs
@@ -40,7 +40,7 @@ namespace Transbank.Webpay.WebpayPlus
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, null);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static CreateResponse Create(string buyOrder, string sessionId,

--- a/Transbank/WebpayRest/WebpayPlus/MallDeferredTransaction.cs
+++ b/Transbank/WebpayRest/WebpayPlus/MallDeferredTransaction.cs
@@ -16,19 +16,6 @@ namespace Transbank.Webpay.WebpayPlus
         private static string _commerceCode = "597055555544";
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
-        
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
 
         public static string CommerceCode
         {
@@ -56,7 +43,7 @@ namespace Transbank.Webpay.WebpayPlus
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static MallCreateResponse Create(string buyOrder, string sessionId, string returnUrl,

--- a/Transbank/WebpayRest/WebpayPlus/MallTransaction.cs
+++ b/Transbank/WebpayRest/WebpayPlus/MallTransaction.cs
@@ -15,18 +15,6 @@ namespace Transbank.Webpay.WebpayPlus
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
 
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
         public static string CommerceCode
         {
             get => _commerceCode;
@@ -53,7 +41,7 @@ namespace Transbank.Webpay.WebpayPlus
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static MallCreateResponse Create(string buyOrder, string sessionId,

--- a/Transbank/WebpayRest/WebpayPlus/Transaction.cs
+++ b/Transbank/WebpayRest/WebpayPlus/Transaction.cs
@@ -5,7 +5,6 @@ using Transbank.Webpay.WebpayPlus.Requests;
 using Transbank.Webpay.Common;
 using Transbank.Webpay.WebpayPlus.Responses;
 using Newtonsoft.Json;
-using Transbank.Webpay.WebpayPlus.Exceptions;
 
 namespace Transbank.Webpay.WebpayPlus
 {
@@ -15,18 +14,6 @@ namespace Transbank.Webpay.WebpayPlus
         private static string _apiKey = "579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C";
         private static WebpayIntegrationType _integrationType = WebpayIntegrationType.Test;
 
-        private static string _commerceCodeHeaderName = "Tbk-Api-Key-Id";
-        private static string _apiKeyHeaderName = "Tbk-Api-Key-Secret";
-
-        private static RequestServiceHeaders _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-
-        public static RequestServiceHeaders Headers
-        {
-            get => _headers;
-            set => _headers = value ?? throw new ArgumentNullException(
-                                  nameof(value), "Integration type can't be null."
-                              );
-        }
         public static string CommerceCode
         {
             get => _commerceCode;
@@ -53,7 +40,7 @@ namespace Transbank.Webpay.WebpayPlus
 
         public static Options DefaultOptions()
         {
-            return new Options(CommerceCode, ApiKey, IntegrationType, Headers);
+            return new Options(CommerceCode, ApiKey, IntegrationType);
         }
 
         public static CreateResponse Create(string buyOrder, string sessionId,


### PR DESCRIPTION
Changed the way custom headers for Patcomercio are set. They used to be public when they shouldn't. 

Now you can call RequestService with custom headers and it is done that way inside classes that need it (Patcomercio Inscription class)

Removed alternative of adding headers to options, that's not something the user should take care of...

These are breaking changes on something people shouldn't use, anyway, we should bump it to the next version