### PR TITLE
Prepare release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2020-11-09
+
+### Fixed
+- Se agregan headers faltantes para Webpay Plus Diferido
+
 ## [2.5.0] - 2020-10-20
 
 ### Added

--- a/Transbank/Transbank.csproj
+++ b/Transbank/Transbank.csproj
@@ -16,7 +16,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>payments, cl, chile, transbank</PackageTags>
     <PackageIconUrl>https://www.transbankdevelopers.cl/favicon.ico</PackageIconUrl>
-    <VersionPrefix>2.5.1</VersionPrefix>
+    <VersionPrefix>2.5.2</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Product>TransbankSDK</Product>
     <Copyright>2020 - Transbank</Copyright>


### PR DESCRIPTION
This fixes some header issues in Webpay Plus Deferido

Full diff: https://github.com/TransbankDevelopers/transbank-sdk-dotnet/compare/v2.5.0...feat/prepare-release-2.5.1