### PR TITLE
add 2.6.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.6.2] - 2023-03-01
+
+### Fixed
+
+- Se actualiza certificado Público de Transbank
+- Se actualiza por seguridad la librería Newtonsoft hacia la versión 13.0.2
+- Se actualiza por seguridad la librería MQTTnet hacia la versión 3.1.2
+
+### Changed
+
+- Se eliminan test deprecados
+
 ## [2.6.1] - 2021-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ SDK Oficial de Transbank
 Al realizar la instalación con NuGet las dependencias
 debieran instalarse automáticamente.
 
-- [Newtonsoft 11.0.2](https://www.newtonsoft.com/json)
-- [Microsoft Web Services 3.0.0](https://www.microsoft.com/en-us/download/details.aspx?id=14089)
+- [Newtonsoft 13.0.2](https://www.newtonsoft.com/json)
+- [Microsoft Web Services 3.1.2](https://www.microsoft.com/en-us/download/details.aspx?id=14089)
 
 ## Instalación
 

--- a/Transbank/Transbank.csproj
+++ b/Transbank/Transbank.csproj
@@ -16,7 +16,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageTags>payments, cl, chile, transbank</PackageTags>
     <PackageIconUrl>https://www.transbankdevelopers.cl/favicon.ico</PackageIconUrl>
-    <VersionPrefix>2.6.2</VersionPrefix>
+    <VersionPrefix>2.6.3</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Product>TransbankSDK</Product>
     <Copyright>2020 - Transbank</Copyright>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ before_deploy:
 deploy:
 - provider: NuGet
   api_key:
-    secure: 9FlFV3ckFidnwYpT8jOCAXI2wPn1yqkHpGl9l1AMRweR+bxjtCSmym/kXABTGxDX
+    secure: y3ZcPs/yht81ncimCIR/Jk16a4b+QS+15w2uoc3/8Ap1RxvzycjS8CgAv1DYK9Vi
   on:
     branch: 2.x
 


### PR DESCRIPTION
- Se actualiza certificado Público de Transbank
- Se actualiza por seguridad la librería Newtonsoft hacia la versión 13.0.2
- Se actualiza por seguridad la librería MQTTnet hacia la versión 3.1.2
- Se eliminan test deprecados
- Se actualiza el apikey de despliegue en el portal Nuget

Full diff: https://github.com/TransbankDevelopers/transbank-sdk-dotnet/compare/v2.6.1...2.x