### PR TITLE
feat: remove default environment configuration

### DIFF
--- a/Tests/FullTransactionTests.cs
+++ b/Tests/FullTransactionTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+using Transbank.Common;
+using Transbank.Webpay.TransaccionCompleta;
+using Transbank.Webpay.TransaccionCompletaMall;
+
+namespace Tests
+{
+    public class FullTransactionTests
+    {
+        [Fact]
+        public void CorrectOptions()
+        {
+            FullTransaction fullTransaction = FullTransaction.buildForIntegration(IntegrationCommerceCodes.TRANSACCION_COMPLETA, IntegrationApiKeys.WEBPAY);
+            MallFullTransaction mallFullTransaction = MallFullTransaction.buildForIntegration(IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal(IntegrationCommerceCodes.TRANSACCION_COMPLETA,
+                fullTransaction.Options.CommerceCode);
+            Assert.Equal(IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
+                mallFullTransaction.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY,
+                fullTransaction.Options.ApiKey);
+            Assert.Equal(IntegrationApiKeys.WEBPAY,
+                mallFullTransaction.Options.ApiKey);
+        }
+
+        [Fact]
+        public void CorrectIntegrationUrl()
+        {
+            FullTransaction transaction = FullTransaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS, IntegrationApiKeys.WEBPAY);
+            MallFullTransaction mallTransaction = MallFullTransaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal("https://webpay3gint.transbank.cl", transaction.Options.IntegrationType.ApiBase);
+            Assert.Equal("https://webpay3gint.transbank.cl", mallTransaction.Options.IntegrationType.ApiBase);
+        }
+
+    }
+}

--- a/Tests/OneclickTests.cs
+++ b/Tests/OneclickTests.cs
@@ -7,16 +7,29 @@ namespace Tests
     public class OneclickTests
     {
         [Fact]
-        public void CorrectDefaultOptions()
+        public void CorrectOptions()
         {
-            Assert.Equal(IntegrationCommerceCodes.ONECLICK_MALL, (new MallTransaction()).Options.CommerceCode);
-            Assert.Equal(IntegrationApiKeys.WEBPAY, (new MallTransaction()).Options.ApiKey);
+            MallTransaction mallTransaction = MallTransaction.buildForIntegration(IntegrationCommerceCodes.ONECLICK_MALL, IntegrationApiKeys.WEBPAY);
+            MallInscription mallInscription = MallInscription.buildForIntegration(IntegrationCommerceCodes.ONECLICK_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal(IntegrationCommerceCodes.ONECLICK_MALL,
+                mallInscription.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY,
+                mallInscription.Options.ApiKey);
+            Assert.Equal(IntegrationCommerceCodes.ONECLICK_MALL,
+                mallTransaction.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY,
+                mallTransaction.Options.ApiKey);
         }
 
         [Fact]
         public void CorrectIntegrationUrl()
         {
-            Assert.Equal("https://webpay3gint.transbank.cl", (new MallTransaction()).Options.IntegrationType.ApiBase);
+            MallTransaction mallTransaction = MallTransaction.buildForIntegration(IntegrationCommerceCodes.ONECLICK_MALL, IntegrationApiKeys.WEBPAY);
+            MallInscription mallInscription = MallInscription.buildForIntegration(IntegrationCommerceCodes.ONECLICK_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal("https://webpay3gint.transbank.cl", 
+                mallTransaction.Options.IntegrationType.ApiBase);
+            Assert.Equal("https://webpay3gint.transbank.cl",
+                mallInscription.Options.IntegrationType.ApiBase);
         }
     }
 }

--- a/Tests/PatpassByWebpayTests.cs
+++ b/Tests/PatpassByWebpayTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using Transbank.Common;
+using Transbank.Patpass.PatpassByWebpay;
+
+namespace Tests
+{
+    public class PatpassByWebpayTests
+    {
+        [Fact]
+        public void CorrectOptions()
+        {
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.PATPASS_BY_WEBPAY, IntegrationApiKeys.WEBPAY);
+            Assert.Equal(IntegrationCommerceCodes.PATPASS_BY_WEBPAY, transaction.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY, transaction.Options.ApiKey);
+        }
+
+        [Fact]
+        public void CorrectIntegrationUrl()
+        {
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.PATPASS_COMERCIO, IntegrationApiKeys.PATPASS_COMERCIO);
+            Assert.Equal("https://webpay3gint.transbank.cl", transaction.Options.IntegrationType.ApiBase);
+        }
+    }
+}

--- a/Tests/PatpassTests.cs
+++ b/Tests/PatpassTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 using Transbank.Common;
 using Transbank.Patpass.PatpassComercio;
@@ -8,16 +7,18 @@ namespace Tests
     public class PatpassTests
     {
         [Fact]
-        public void CorrectDefaultOptions()
+        public void CorrectOptions()
         {
-            Assert.Equal(IntegrationCommerceCodes.PATPASS_COMERCIO, (new Inscription()).Options.CommerceCode);
-            Assert.Equal(IntegrationApiKeys.PATPASS_COMERCIO, (new Inscription()).Options.ApiKey);
+            Inscription inscription = Inscription.buildForIntegration(IntegrationCommerceCodes.PATPASS_COMERCIO, IntegrationApiKeys.PATPASS_COMERCIO);
+            Assert.Equal(IntegrationCommerceCodes.PATPASS_COMERCIO, inscription.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.PATPASS_COMERCIO, inscription.Options.ApiKey);
         }
 
         [Fact]
         public void CorrectIntegrationUrl()
         {
-            Assert.Equal("https://pagoautomaticocontarjetasint.transbank.cl", (new Inscription()).Options.IntegrationType.ApiBase);
+            Inscription inscription = Inscription.buildForIntegration(IntegrationCommerceCodes.PATPASS_COMERCIO, IntegrationApiKeys.PATPASS_COMERCIO);
+            Assert.Equal("https://pagoautomaticocontarjetasint.transbank.cl", inscription.Options.IntegrationType.ApiBase);
         }
     }
 }

--- a/Tests/WebpayModalTests.cs
+++ b/Tests/WebpayModalTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using Transbank.Common;
+using Transbank.Webpay.Modal;
+
+namespace Tests
+{
+    public class WebpayModalTests
+    {
+        [Fact]
+        public void CorrectOptions()
+        {
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS_MODAL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal(IntegrationCommerceCodes.WEBPAY_PLUS_MODAL, transaction.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY, transaction.Options.ApiKey);
+        }
+
+        [Fact]
+        public void CorrectIntegrationUrl()
+        {
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS_MODAL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal("https://webpay3gint.transbank.cl", transaction.Options.IntegrationType.ApiBase);
+        }
+    }
+}

--- a/Tests/WebpayPlusTest.cs
+++ b/Tests/WebpayPlusTest.cs
@@ -7,19 +7,23 @@ namespace Tests
     public class WebpayPlusTests
     {
         [Fact]
-        public void CorrectDefaultOptions()
+        public void CorrectOptions()
         {
-            Assert.Equal(IntegrationCommerceCodes.WEBPAY_PLUS, (new Transaction()).Options.CommerceCode);
-            Assert.Equal(IntegrationCommerceCodes.WEBPAY_PLUS_MALL, (new MallTransaction()).Options.CommerceCode);
-            Assert.Equal(IntegrationApiKeys.WEBPAY, (new Transaction()).Options.ApiKey);
-            Assert.Equal(IntegrationApiKeys.WEBPAY, (new MallTransaction()).Options.ApiKey);
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS, IntegrationApiKeys.WEBPAY);
+            MallTransaction mallTransaction = MallTransaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal(IntegrationCommerceCodes.WEBPAY_PLUS, transaction.Options.CommerceCode);
+            Assert.Equal(IntegrationCommerceCodes.WEBPAY_PLUS_MALL, mallTransaction.Options.CommerceCode);
+            Assert.Equal(IntegrationApiKeys.WEBPAY, transaction.Options.ApiKey);
+            Assert.Equal(IntegrationApiKeys.WEBPAY, mallTransaction.Options.ApiKey);
         }
 
         [Fact]
         public void CorrectIntegrationUrl()
         {
-            Assert.Equal("https://webpay3gint.transbank.cl", (new Transaction()).Options.IntegrationType.ApiBase);
-            Assert.Equal("https://webpay3gint.transbank.cl", (new MallTransaction()).Options.IntegrationType.ApiBase);
+            Transaction transaction = Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS, IntegrationApiKeys.WEBPAY);
+            MallTransaction mallTransaction = MallTransaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS_MALL, IntegrationApiKeys.WEBPAY);
+            Assert.Equal("https://webpay3gint.transbank.cl", transaction.Options.IntegrationType.ApiBase);
+            Assert.Equal("https://webpay3gint.transbank.cl", mallTransaction.Options.IntegrationType.ApiBase);
         }
     }
 }

--- a/Transbank/Patpass/PatpassByWebpay/Transaction.cs
+++ b/Transbank/Patpass/PatpassByWebpay/Transaction.cs
@@ -10,11 +10,25 @@ namespace Transbank.Patpass.PatpassByWebpay
 {
     public class Transaction : BaseOptions
     {
-        public Transaction() { ConfigureForTesting(); }
+        private Transaction() {  }
 
         public Transaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public Transaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+
+        public static Transaction buildForProduction(string commerceCode, string apiKey)
+        {
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForProduction(commerceCode, apiKey);
+            return transaction;
+        }
+        
+        public static Transaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForIntegration(commerceCode, apiKey);
+            return transaction;
+        }
 
         public CreateResponse Create(string buyOrder, string sessionId, decimal amount, string returnUrl, string serviceId, string cardHolderId,
                 string cardHolderName, string cardHolderLastName1, string cardHolderLastName2, string cardHolderMail, string cellphoneNumber,

--- a/Transbank/Patpass/PatpassComercio/Inscription.cs
+++ b/Transbank/Patpass/PatpassComercio/Inscription.cs
@@ -18,9 +18,8 @@ namespace Transbank.Patpass.PatpassComercio
 
         private RequestServiceHeaders _headers;
 
-        public Inscription() {
+        private Inscription() {
             _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
-            ConfigureForTesting(); 
         }
         public Inscription(Options options, HttpClient httpClient = null) : base(options, httpClient) {
             _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
@@ -34,6 +33,22 @@ namespace Transbank.Patpass.PatpassComercio
         {
             Options = options;
             _headers = new RequestServiceHeaders(_apiKeyHeaderName, _commerceCodeHeaderName);
+        }
+
+        public static Inscription buildForProduction(string commerceCode, string apiKey)
+        {
+            Inscription inscription = new Inscription();
+            inscription.ConfigureForIntegration(commerceCode, apiKey);
+
+            return inscription;
+        }
+
+        public static Inscription buildForIntegration(string commerceCode, string apiKey)
+        {
+            Inscription inscription = new Inscription();
+            inscription.ConfigureForIntegration(commerceCode, apiKey);
+
+            return inscription;
         }
 
         public StartResponse Start(

--- a/Transbank/Webpay/Modal/Transaction.cs
+++ b/Transbank/Webpay/Modal/Transaction.cs
@@ -10,10 +10,28 @@ namespace Transbank.Webpay.Modal
 {
     public class Transaction :  WebpayOptions
     {
-        public Transaction() { ConfigureForTesting(); }
+        private Transaction() {  }
         public Transaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public Transaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+
+        public static Transaction buildForProduction(string commerceCode, string apiKey)
+        {
+
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForProduction(commerceCode, apiKey);
+            return transaction;
+
+        }
+
+        public static Transaction buildForIntegration(string commerceCode, string apiKey)
+        {
+
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForIntegration(commerceCode, apiKey);
+            return transaction;
+
+        }
 
         public CreateResponse Create(string buyOrder, string sessionId,
             decimal amount)

--- a/Transbank/Webpay/Oneclick/MallInscription.cs
+++ b/Transbank/Webpay/Oneclick/MallInscription.cs
@@ -8,10 +8,26 @@ namespace Transbank.Webpay.Oneclick
 {
     public class MallInscription : OneclickOptions
     {
-        public MallInscription() { ConfigureForTesting(); }
+        private MallInscription() { }
         public MallInscription(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public MallInscription(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+
+        public static MallInscription buildForProduction(string commerceCode, string apiKey)
+        {
+            MallInscription mallInscription = new MallInscription();
+            mallInscription.ConfigureForProduction(commerceCode, apiKey);
+
+            return mallInscription;
+        }
+
+        public static MallInscription buildForIntegration(string commerceCode, string apiKey)
+        {
+            MallInscription mallInscription = new MallInscription();
+            mallInscription.ConfigureForIntegration(commerceCode, apiKey);
+            
+            return mallInscription;
+        }
 
         public MallStartResponse Start(string userName, string email,
             string responseUrl)

--- a/Transbank/Webpay/Oneclick/MallTransaction.cs
+++ b/Transbank/Webpay/Oneclick/MallTransaction.cs
@@ -10,10 +10,26 @@ namespace Transbank.Webpay.Oneclick
 {
     public class MallTransaction : OneclickOptions
     {
-        public MallTransaction(){ ConfigureForTesting(); }
+        private MallTransaction(){ }
         public MallTransaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public MallTransaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+        
+        public static MallTransaction buildForProduction(string commerceCode, string apiKey)
+        {
+            MallTransaction mallTransaction = new MallTransaction();
+            mallTransaction.ConfigureForProduction(commerceCode, apiKey);
+
+            return mallTransaction;
+        }
+
+        public static MallTransaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            MallTransaction mallTransaction = new MallTransaction();
+            mallTransaction.ConfigureForIntegration(commerceCode, apiKey);
+            
+            return mallTransaction;
+        }
 
         public MallAuthorizeResponse Authorize(string userName, string tbkUser, string parentBuyOrder,
             List<PaymentRequest> details)

--- a/Transbank/Webpay/TransaccionCompleta/FullTransaction.cs
+++ b/Transbank/Webpay/TransaccionCompleta/FullTransaction.cs
@@ -10,10 +10,27 @@ namespace Transbank.Webpay.TransaccionCompleta
 {
     public class FullTransaction : WebpayOptions
     {
-        public FullTransaction() { ConfigureForTesting(); }
+        private FullTransaction() { }
         public FullTransaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public FullTransaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+        
+        public static FullTransaction buildForProduction(string commerceCode, string apiKey)
+        {
+            FullTransaction fullTransaction = new FullTransaction();
+            fullTransaction.ConfigureForProduction(commerceCode, apiKey);
+
+            return fullTransaction;
+        }
+
+        public static FullTransaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            FullTransaction fullTransaction = new FullTransaction();
+            fullTransaction.ConfigureForIntegration(commerceCode, apiKey);
+
+            return fullTransaction;
+        }
+        
         public CreateResponse Create(
             string buyOrder,
             string sessionId,

--- a/Transbank/Webpay/TransaccionCompletaMall/MallFullTransaction.cs
+++ b/Transbank/Webpay/TransaccionCompletaMall/MallFullTransaction.cs
@@ -13,10 +13,26 @@ namespace Transbank.Webpay.TransaccionCompletaMall
 {
     public class MallFullTransaction : WebpayOptions
     {
-        public MallFullTransaction() { ConfigureForTesting(); }
+        private MallFullTransaction() { }
         public MallFullTransaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public MallFullTransaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+        
+        public static MallFullTransaction buildForProduction(string commerceCode, string apiKey)
+        {
+            MallFullTransaction mallFullTransaction = new MallFullTransaction();
+            mallFullTransaction.ConfigureForProduction(commerceCode, apiKey);
+
+            return mallFullTransaction;
+        }
+
+        public static MallFullTransaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            MallFullTransaction mallFullTransaction = new MallFullTransaction();
+            mallFullTransaction.ConfigureForIntegration(commerceCode, apiKey);
+            
+            return mallFullTransaction;
+        }
 
         public  MallCreateResponse Create(
             string buyOrder,

--- a/Transbank/Webpay/WebpayPlus/MallTransaction.cs
+++ b/Transbank/Webpay/WebpayPlus/MallTransaction.cs
@@ -10,11 +10,27 @@ namespace Transbank.Webpay.WebpayPlus
 {
     public class MallTransaction : WebpayOptions
     {
-        public MallTransaction() { ConfigureForTesting(); }
+        private MallTransaction() { }
         public MallTransaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public MallTransaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null)
             : base(commerceCode, apiKey, integrationType, httpClient) { }
 
+        public static MallTransaction buildForProduction (string commerceCode, string apiKey)
+        {
+            MallTransaction mallTransaction = new MallTransaction();
+            mallTransaction.ConfigureForProduction(commerceCode, apiKey);
+
+            return mallTransaction;
+        }
+
+        public static MallTransaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            MallTransaction mallTransaction = new MallTransaction();
+            mallTransaction.ConfigureForIntegration(commerceCode, apiKey);
+
+            return mallTransaction;
+        }
+        
         public MallCreateResponse Create(string buyOrder, string sessionId,
             string returnUrl, List<TransactionDetail> details)
         {

--- a/Transbank/Webpay/WebpayPlus/Transaction.cs
+++ b/Transbank/Webpay/WebpayPlus/Transaction.cs
@@ -10,10 +10,26 @@ namespace Transbank.Webpay.WebpayPlus
 {
     public class Transaction : WebpayOptions
     {
-        public Transaction() { ConfigureForTesting(); }
+        private Transaction() { }
         public Transaction(Options options, HttpClient httpClient = null) : base(options, httpClient) { }
         public Transaction(string commerceCode, string apiKey, IIntegrationType integrationType, HttpClient httpClient = null) 
             : base(commerceCode, apiKey, integrationType, httpClient) { }
+
+        public static Transaction buildForProduction(string commerceCode, string apiKey) 
+        {
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForProduction(commerceCode, apiKey);
+
+            return transaction;
+        }
+
+        public static Transaction buildForIntegration(string commerceCode, string apiKey)
+        {
+            Transaction transaction = new Transaction();
+            transaction.ConfigureForIntegration(commerceCode, apiKey);
+            
+            return transaction;
+        }
 
         public CreateResponse Create(string buyOrder, string sessionId,
             decimal amount, string returnUrl)


### PR DESCRIPTION
This PR removes the default configuration for integration environment on all products.
Now is necessary use a build method for integration or production environment to create an object.
**This is a breaking change, now the integrator must always have control of the environment in which they will use the product, using the corresponding method and credentials.**

For example, to create a Webpay Plus Transaction now you must call their corresponding build method.

Integration:
`Transaction transaction = Transaction.buildForIntegration("integrationCommerceCode", "integrationApiKey"); `

Production:
`Transaction transaction = Transaction.buildForProduction("productionCommerceCode", "productionApiKey"); `

